### PR TITLE
io.c: Fix mmap() error check

### DIFF
--- a/2020-2021/Laboratories/io/io.c
+++ b/2020-2021/Laboratories/io/io.c
@@ -203,7 +203,7 @@ io(const char *path)
 		 */
 		buf = mmap(NULL, buffersize, PROT_READ | PROT_WRITE, MAP_ANON,
 		    -1, 0);
-		if (buf == NULL)
+		if (buf == MAP_FAILED)
 			xo_err(EX_OSERR, "FAIL: mmap");
 
 		/*

--- a/2020-2021/Laboratories/io/io.c
+++ b/2020-2021/Laboratories/io/io.c
@@ -201,8 +201,8 @@ io(const char *path)
 		/*
 		 * Allocate zero-filled memory for our I/O buffer.
 		 */
-		buf = mmap(NULL, buffersize, PROT_READ | PROT_WRITE, MAP_ANON,
-		    -1, 0);
+		buf = mmap(NULL, buffersize, PROT_READ | PROT_WRITE,
+		    MAP_ANON | MAP_PRIVATE, -1, 0);
 		if (buf == MAP_FAILED)
 			xo_err(EX_OSERR, "FAIL: mmap");
 


### PR DESCRIPTION
We have to compare to MAP_FAILED and not NULL