### PR TITLE
Add missing labels for TEXT output.

### DIFF
--- a/2021-2022/Laboratories/ipc/ipc.c
+++ b/2021-2022/Laboratories/ipc/ipc.c
@@ -1329,12 +1329,14 @@ ipc(void)
 			f = pmc_values[COUNTERSET_INSTR_INDEX_L1I_CACHE] -
 			    pmc_values[COUNTERSET_INSTR_INDEX_L1I_CACHE_REFILL];
 			f /= pmc_values[COUNTERSET_INSTR_INDEX_L1I_CACHE];
-			xo_emit("  {:L1I_CACHE_HIT_RATE/%F}\n", f);
+			xo_emit("  L1I_CACHE_HIT_RATE: "
+			    "{:L1I_CACHE_HIT_RATE/%F}\n", f);
 
 			f = pmc_values[COUNTERSET_INSTR_INDEX_BR_PRED];
 			f /= pmc_values[COUNTERSET_INSTR_INDEX_BR_MIS_PRED] +
 			    pmc_values[COUNTERSET_INSTR_INDEX_BR_PRED];
-			xo_emit("  {:BR_PRED_RATE/%F}\n", f);
+			xo_emit("  BR_PRED_RATE: "
+			    "{:BR_PRED_RATE/%F}\n", f);
 		}
 #endif
 		if (!qflag) {


### PR DESCRIPTION
L1I_CACHE_HIT_RATE and BR_PRED_RATE are missing labels when output is not formatted with JSON:
```
root@rpi4-000:/data # ipc/ipc-benchmark -i pipe -P instr -j 2proc
{
  "benchmark_samples": [
    {
      "bandwidth": 562256.21,
      "time": "0.029139739",
      "INST_RETIRED": 7766641,
      "CPU_CYCLES": 11924284,
      "L1I_CACHE": 3251402,
      "L1I_CACHE_REFILL": 39817,
      "BR_MIS_PRED": 15505,
      "BR_PRED": 1100812,
      "CYCLES_PER_INSTRUCTION": 1.535321,
      "L1I_CACHE_HIT_RATE": 0.987754,
      "BR_PRED_RATE": 0.986111
    }
  ]
}
root@rpi4-000:/data # ipc/ipc-benchmark -i pipe -P instr 2proc
datum:
  bandwidth: 552237.78 KBytes/sec
  time: 0.029668381 seconds
  INST_RETIRED: 7986865
  CPU_CYCLES: 12207873
  L1I_CACHE: 3376224
  L1I_CACHE_REFILL: 41196
  BR_MIS_PRED: 16580
  BR_PRED: 1153167
  CYCLES_PER_INSTRUCTION: 1.528494
  0.987798
  0.985826
root@rpi4-000:/data # 
```
This change adds the missing labels:
```
root@rpi4-000:/data # ipc/ipc-benchmark -i pipe -P instr 2proc
datum:
  bandwidth: 556994.13 KBytes/sec
  time: 0.029415033 seconds
  INST_RETIRED: 7980513
  CPU_CYCLES: 12086670
  L1I_CACHE: 3339922
  L1I_CACHE_REFILL: 40610
  BR_MIS_PRED: 16232
  BR_PRED: 1143965
  CYCLES_PER_INSTRUCTION: 1.514523
  L1I_CACHE_HIT_RATE: 0.987841
  BR_PRED_RATE: 0.986009
root@rpi4-000:/data # 
```