### PR TITLE
Run 'syscall:::entry' rather than 'syscall:::' to count system calls.

### DIFF
--- a/2022-2023/Laboratories/2022-2023-advopsys-lab1.ipynb
+++ b/2022-2023/Laboratories/2022-2023-advopsys-lab1.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!dtrace -n 'syscall::: /execname == \"dd\"/ { @syscalls[probefunc] = count(); }' -c 'dd if=/dev/zero of=/dev/null bs=1k count=10000'"
+    "!dtrace -n 'syscall:::entry /execname == \"dd\"/ { @syscalls[probefunc] = count(); }' -c 'dd if=/dev/zero of=/dev/null bs=1k count=10000'"
    ]
   },
   {
@@ -163,7 +163,7 @@
    "source": [
     "# Sample D-language script embedded in a Python string.\n",
     "syscall_count_script = \"\"\"\n",
-    "syscall::: /execname == \"dd\"/ { @syscalls[probefunc] = count(); }\n",
+    "syscall:::entry /execname == \"dd\"/ { @syscalls[probefunc] = count(); }\n",
     "\"\"\"\n",
     "\n",
     "from collections import defaultdict\n",


### PR DESCRIPTION
Using `syscall:::` when trying to count system calls will count up both the `syscall:::entry` and `syscall:::return`. This pull request just ensures that we only count up the `entry` points of the system call.