### PR TITLE
Add a Jupyter notebook configuration file

### DIFF
--- a/2023-2024/Laboratories/jupyter_notebook_config.py
+++ b/2023-2024/Laboratories/jupyter_notebook_config.py
@@ -1,0 +1,3 @@
+# Disable cross-site-request-forgery protection.
+# Without this setting, Chrome and Safari cannot generate PDFs.
+c.ServerApp.disable_check_xsrf = True


### PR DESCRIPTION
Disable cross-site-request-forgery protection in the file to allow Chrome and Safari browsers use the export to PDF feature.

The configuration file has the default file name. There is no need to use a jupyter-lab flag or install the file as long as a jupyter-lab command is executed in the same directory as the configuration file is stored in.