### PR TITLE
lab2: use a specific Armv8-A reference version

### DIFF
--- a/2023-2024/Laboratories/2023-2024-advopsys-lab2.ipynb
+++ b/2023-2024/Laboratories/2023-2024-advopsys-lab2.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "- [Raspberry Pi 4 - Broadcom 2711 (BCM2711)](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md)\n",
     "- [ARM® Cortex®-A72 MPCore Processor - see section 11.8](https://developer.arm.com/documentation/100095/0003)\n",
-    "- [Arm Architecture Reference Manual Armv8, for Armv8-A architecture profile - see sections D7.11.3 and Appendix K3](https://developer.arm.com/documentation/ddi0487/latest/)\n"
+    "- [Arm Architecture Reference Manual Armv8, for Armv8-A architecture profile - see sections D7.11.3 and Appendix K3](https://developer.arm.com/documentation/ddi0487/fc/)\n"
    ]
   },
   {


### PR DESCRIPTION
The course website should be updated to use a specific document version and the same chapter numbers (it refers to D7.10 instead of D7.11.3).